### PR TITLE
Release 1.2.0 with parse and ts-money as peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goplan-finance/utils",
-  "version": "1.1.4",  
+  "version": "1.2.0",
   "description": "",
   "keywords": [
     "finance",
@@ -36,12 +36,11 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "axios": "^1.3.4",
-    "crypto-js": "^4.2.0",
-    "parse": "^5.3.0",
-    "prettier": "^3.0.0",
-    "ts-money": "^0.4.8",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.6.2"
+    "crypto-js": "^4.2.0"
+  },
+  "peerDependencies": {
+    "parse": ">=5.3.0 <8",
+    "ts-money": "^0.4.8"
   },
   "devDependencies": {
     "@types/bson": "^4.2.0",
@@ -55,8 +54,13 @@
     "eslint-plugin-varspacing": "1.2.2",
     "eslint-plugin-vue": "9.29.1",
     "jest": "^29.7.0",
+    "parse": "^7.1.2",
     "pre-commit": "1.2.2",
-    "ts-jest": "^29.0.5"
+    "prettier": "^3.0.0",
+    "ts-jest": "^29.0.5",
+    "ts-money": "^0.4.8",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.6.2"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/CryptoUtils.ts
+++ b/src/CryptoUtils.ts
@@ -129,13 +129,9 @@ export default class Crypto {
 
   static async PBKDF2(masterKey: string, salt: Uint8Array<ArrayBuffer>): Promise<DerivedKey> {
     const keyMaterial = encodeUtf8(masterKey);
-    const key = await window.crypto.subtle.importKey(
-      'raw',
-      keyMaterial,
-      'PBKDF2',
-      false,
-      ['deriveKey']
-    );
+    const key = await window.crypto.subtle.importKey('raw', keyMaterial, 'PBKDF2', false, [
+      'deriveKey',
+    ]);
 
     const derivedKey = await window.crypto.subtle.deriveKey(
       {

--- a/src/parse/Query.ts
+++ b/src/parse/Query.ts
@@ -11,14 +11,7 @@ import { SecureObject } from './SecureObject';
 import { ObjectPathUtils } from '../ObjectPathUtils';
 
 export type LiveQueryUpdateFnEventType =
-  | null
-  | 'open'
-  | 'create'
-  | 'update'
-  | 'enter'
-  | 'leave'
-  | 'delete'
-  | 'close';
+  null | 'open' | 'create' | 'update' | 'enter' | 'leave' | 'delete' | 'close';
 
 export type LiveQueryUpdateFn<T> = (obj: T, event: LiveQueryUpdateFnEventType) => void;
 export type Constructible<T> = new (...args: unknown[]) => T;
@@ -458,7 +451,9 @@ export default class Query<T extends Parse.Object> extends Parse.Query<T> {
 
   // Overloads to support passing options (for sessionToken) while remaining compatible
   // with base Parse.Query types (which omit the options param in .d.ts but runtime accepts it)
-  public aggregate<V = unknown>(pipeline: Parse.Query.AggregationOptions | Parse.Query.AggregationOptions[]): Promise<V>;
+  public aggregate<V = unknown>(
+    pipeline: Parse.Query.AggregationOptions | Parse.Query.AggregationOptions[]
+  ): Promise<V>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-dupe-class-members
   public aggregate(pipeline: any, options?: any): Promise<any> {
     options = this.prepareOptions(options);


### PR DESCRIPTION
Move parse/ts-money out of dependencies so consumers (e.g. parse-server 8 / Parse JS SDK 7) share a single package instance and avoid dual Money constructors. Keep parse ^7.1.2 in devDependencies for local tests.