### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "@goplan-finance/utils",
+  "install": "yarn install",
+  "terminals": [
+    {
+      "name": "tsc-watch",
+      "command": "yarn watch"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for `@goplan-finance/utils`, a TypeScript utility library for Parse-Server / Parse-SDK.

The repository uses Node 22 + Yarn 1.22 (both provided by Cursor's default image), so no custom Dockerfile is needed.

### `.cursor/environment.json`
- `install`: `yarn install` — installs dependencies (and runs the package's `prepare`/`prepublish` scripts, which build via `tsc` and run the jest suite).
- `terminals.tsc-watch`: `yarn watch` — runs `tsc --watch` for the documented incremental dev flow, with visible logs.

## Validation
All performed on the VM:
- `yarn install` — succeeds, and is idempotent (run twice).
- `yarn build` (`tsc`) — compiles with 0 errors, emits `dist/`.
- `yarn test` (`jest`) — 73 tests across 8 suites pass.
- `yarn lint` (`eslint`) — clean.
- End-to-end runtime usage — imported compiled modules from `dist/` and invoked utilities (`MathUtils`, `StringUtils`, `ArrayUtils`, `DomainNameUtils`); loaded the full barrel with the `parse` peer wired as the global `Parse`, exposing all 21 exports.
- `yarn watch` terminal — reports "Found 0 errors. Watching for file changes."

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b6bce29-e114-4bd6-8d18-9b8e15f1dc58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b6bce29-e114-4bd6-8d18-9b8e15f1dc58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

