### PR TITLE
Fix confirmed bugs and close test gaps

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -22,8 +22,10 @@ export default {
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: true,
 
-  // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  // An array of glob patterns indicating a set of files for which coverage information should be collected.
+  // Explicitly listing the source tree ensures files with no tests still appear (as 0%) instead of being
+  // silently omitted from the coverage report.
+  collectCoverageFrom: ['src/**/*.ts'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
@@ -139,7 +141,7 @@ export default {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['<rootDir>/spec/jestSetup.ts'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/spec/ArrayUtils.spec.ts
+++ b/spec/ArrayUtils.spec.ts
@@ -10,11 +10,13 @@ describe('ArrayUtils', () => {
       expect(val).toStrictEqual([1, 2, 3, 4]);
     });
 
-    it('should remove duplicate items', function () {
-      const data = [1, 2, 3, 4, 4, 4];
+    it('should pass the index to the initializer', function () {
+      const val = ArrayUtils.fillWith(3, index => index * 2);
+      expect(val).toStrictEqual([0, 2, 4]);
+    });
 
-      const val = ArrayUtils.unique(data);
-      expect(val).toStrictEqual([1, 2, 3, 4]);
+    it('should return an empty array for length 0', function () {
+      expect(ArrayUtils.fillWith(0, () => 1)).toStrictEqual([]);
     });
   });
 
@@ -153,53 +155,37 @@ describe('ArrayUtils', () => {
   });
 
   describe('randomElement', () => {
-    it('should return one of the array element randomly', () => {
-      const setMock = (val: number) => {
-        const mockMath = Object.create(global.Math);
-        mockMath.random = () => val;
-        global.Math = mockMath;
-      };
+    let randomSpy: jest.SpyInstance;
 
-      const arr = Array.from(Array(100).keys());
-
-      setMock(0);
-      expect(ArrayUtils.randomElement(arr)).toBe(0);
-
-      setMock(0.01);
-      expect(ArrayUtils.randomElement(arr)).toBe(0);
-
-      setMock(0.5);
-      expect(ArrayUtils.randomElement(arr)).toBe(49);
-
-      setMock(1);
-      expect(ArrayUtils.randomElement(arr)).toBe(99);
+    afterEach(() => {
+      randomSpy?.mockRestore();
     });
 
-    it('should return one of the array element randomly', () => {
-      const setMock = (val: number) => {
-        const mockMath = Object.create(global.Math);
-        mockMath.random = () => val;
-        global.Math = mockMath;
-      };
+    const mockRandom = (val: number) => {
+      randomSpy = jest.spyOn(Math, 'random').mockReturnValue(val);
+    };
 
+    it('should map Math.random() across the full index range', () => {
       const arr = Array.from(Array(100).keys());
 
-      setMock(0);
+      mockRandom(0);
       expect(ArrayUtils.randomElement(arr)).toBe(0);
 
-      setMock(0.01);
-      expect(ArrayUtils.randomElement(arr)).toBe(0);
+      mockRandom(0.5);
+      expect(ArrayUtils.randomElement(arr)).toBe(50);
+    });
 
-      setMock(0.5);
-      expect(ArrayUtils.randomElement(arr)).toBe(49);
+    it('should be able to return the LAST element (regression: off-by-one)', () => {
+      // Math.random() returns [0, 1); a value just below 1 must select the final index.
+      mockRandom(0.999999);
+      expect(ArrayUtils.randomElement([10, 20, 30])).toBe(30);
 
-      setMock(1);
-      expect(ArrayUtils.randomElement(arr)).toBe(99);
+      // A two-element array must be able to yield its second element.
+      mockRandom(0.5);
+      expect(ArrayUtils.randomElement([1, 2])).toBe(2);
     });
 
     it('should throw when provided array is empty', () => {
-      const arr = Array.from(Array(100).keys());
-
       expect(() => ArrayUtils.randomElement([])).toThrowError('provided array is empty');
     });
   });
@@ -219,10 +205,79 @@ describe('ArrayUtils', () => {
       });
     });
 
-    it('should throw when provided array is empty', () => {
-      const arr = Array.from(Array(100).keys());
+    it('should return null when the array is empty', () => {
+      const output = ArrayUtils.filterByValue(
+        [],
+        (a, b) => a > b,
+        elem => elem
+      );
 
-      expect(() => ArrayUtils.randomElement([])).toThrowError('provided array is empty');
+      expect(output).toBeNull();
+    });
+  });
+
+  describe('shuffle', () => {
+    it('should keep the same elements (as a multiset)', () => {
+      const input = [1, 2, 3, 4, 5];
+      const result = ArrayUtils.shuffle([...input]);
+
+      expect(result).toHaveLength(input.length);
+      expect([...result].sort((a, b) => a - b)).toStrictEqual(input);
+    });
+  });
+
+  describe('uniqueByKey', () => {
+    it('should keep the first item for each distinct key value', () => {
+      const data = [
+        { id: 1, name: 'a' },
+        { id: 1, name: 'b' },
+        { id: 2, name: 'c' },
+      ];
+
+      expect(ArrayUtils.uniqueByKey(data, 'id')).toStrictEqual([
+        { id: 1, name: 'a' },
+        { id: 2, name: 'c' },
+      ]);
+    });
+  });
+
+  describe('sortByKey', () => {
+    const data = () => [{ v: 3 }, { v: 1 }, { v: 2 }];
+
+    it('should sort ascending by default', () => {
+      expect(ArrayUtils.sortByKey(data(), 'v')).toStrictEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
+    });
+
+    it('should sort descending when ascending is false', () => {
+      expect(ArrayUtils.sortByKey(data(), 'v', false)).toStrictEqual([
+        { v: 3 },
+        { v: 2 },
+        { v: 1 },
+      ]);
+    });
+  });
+
+  describe('toKeyArray', () => {
+    it('should index objects by the given key', () => {
+      const data = [
+        { id: 'a', n: 1 },
+        { id: 'b', n: 2 },
+      ];
+
+      expect(ArrayUtils.toKeyArray(data, 'id')).toStrictEqual({
+        a: { id: 'a', n: 1 },
+        b: { id: 'b', n: 2 },
+      });
+    });
+  });
+
+  describe('sum', () => {
+    it('should sum the values produced by the callback', () => {
+      expect(ArrayUtils.sum([{ n: 1 }, { n: 2 }, { n: 3 }], item => item.n)).toBe(6);
+    });
+
+    it('should return 0 for an empty array', () => {
+      expect(ArrayUtils.sum([], (item: { n: number }) => item.n)).toBe(0);
     });
   });
 });

--- a/spec/CryptoUtils.spec.ts
+++ b/spec/CryptoUtils.spec.ts
@@ -1,0 +1,52 @@
+import Crypto from '@utils/CryptoUtils';
+
+describe('CryptoUtils (Crypto)', () => {
+  const validEncrypted = {
+    ct: 'cipher',
+    iv: 'iv',
+    kVer: 1,
+    aVer: 2,
+  };
+
+  describe('isEncrypted', () => {
+    it('should return true for a well-formed encrypted value', () => {
+      expect(Crypto.isEncrypted({ ...validEncrypted })).toBe(true);
+    });
+
+    it('should return false when a required key is missing', () => {
+      const { ct: _ct, ...missingCt } = validEncrypted;
+      expect(Crypto.isEncrypted(missingCt as unknown as Record<string, unknown>)).toBe(false);
+    });
+
+    it('should return false when a required key has the wrong type', () => {
+      expect(Crypto.isEncrypted({ ...validEncrypted, kVer: '1' })).toBe(false);
+    });
+
+    it('should return false for non-object / null / undefined inputs', () => {
+      expect(Crypto.isEncrypted(null as unknown as Record<string, unknown>)).toBe(false);
+      expect(Crypto.isEncrypted(undefined as unknown as Record<string, unknown>)).toBe(false);
+      expect(Crypto.isEncrypted('str' as unknown as Record<string, unknown>)).toBe(false);
+    });
+
+    describe('strict mode (default)', () => {
+      it('should return false when extra keys are present', () => {
+        expect(Crypto.isEncrypted({ ...validEncrypted, extra: 'nope' })).toBe(false);
+      });
+    });
+
+    describe('non-strict mode', () => {
+      it('should allow extra keys', () => {
+        expect(Crypto.isEncrypted({ ...validEncrypted, extra: 'ok' }, false)).toBe(true);
+      });
+    });
+  });
+
+  describe('buffToStr / strToBuff', () => {
+    it('should round-trip a byte array through base64', () => {
+      const bytes = Uint8Array.from([0, 1, 2, 250, 255]);
+      const b64 = Crypto.buffToStr(bytes);
+      const restored = Crypto.strToBuff(b64);
+      expect(Array.from(restored)).toStrictEqual(Array.from(bytes));
+    });
+  });
+});

--- a/spec/CurrencyUtils.spec.ts
+++ b/spec/CurrencyUtils.spec.ts
@@ -1,0 +1,45 @@
+import { CurrencyUtils } from '@utils/CurrencyUtils';
+
+describe('CurrencyUtils', () => {
+  describe('getCurrencyInfo', () => {
+    it('should return the default info when currency is null', () => {
+      expect(CurrencyUtils.getCurrencyInfo(null)).toStrictEqual({
+        decimal_digits: 2,
+        symbol: '$',
+      });
+    });
+
+    it('should return info for a known currency (case-insensitive)', () => {
+      const info = CurrencyUtils.getCurrencyInfo('usd');
+      expect(info.symbol).toBe('$');
+      expect(typeof info.decimal_digits).toBe('number');
+    });
+
+    it('should throw for an unknown currency', () => {
+      let thrown: unknown;
+      try {
+        CurrencyUtils.getCurrencyInfo('NOPE');
+      } catch (e) {
+        thrown = e;
+      }
+      expect(String(thrown)).toContain('Currency not found');
+    });
+  });
+
+  describe('formatCurrency', () => {
+    it('should format with two decimals by default (fixedDecimals)', () => {
+      expect(CurrencyUtils.formatCurrency(1234.5, 'USD', true, 'en-US', undefined)).toBe(
+        '$1,234.50'
+      );
+    });
+
+    it('should drop trailing decimals when fixedDecimals is false', () => {
+      expect(CurrencyUtils.formatCurrency(1000, 'USD', false, 'en-US', undefined)).toBe('$1,000');
+    });
+
+    it('should return an empty string for null/undefined values', () => {
+      expect(CurrencyUtils.formatCurrency(null, 'USD', true, 'en-US', undefined)).toBe('');
+      expect(CurrencyUtils.formatCurrency(undefined, 'USD', true, 'en-US', undefined)).toBe('');
+    });
+  });
+});

--- a/spec/MoneyUtils.spec.ts
+++ b/spec/MoneyUtils.spec.ts
@@ -1,0 +1,34 @@
+import { MoneyUtils } from '@utils/MoneyUtils';
+import { Money } from 'ts-money';
+
+describe('MoneyUtils', () => {
+  describe('fromAmount', () => {
+    it('should build a Money instance from an integer amount', () => {
+      const money = MoneyUtils.fromAmount(1234);
+      expect(money).toBeInstanceOf(Money);
+      expect(money?.getAmount()).toBe(1234);
+    });
+
+    it('should return null for a non-integer amount', () => {
+      expect(MoneyUtils.fromAmount(12.34)).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(MoneyUtils.fromAmount(null)).toBeNull();
+    });
+  });
+
+  describe('toAmount', () => {
+    it('should return the integer amount of a Money instance', () => {
+      expect(MoneyUtils.toAmount(new Money(500, 'CAD'))).toBe(500);
+    });
+
+    it('should return null for null input', () => {
+      expect(MoneyUtils.toAmount(null)).toBeNull();
+    });
+
+    it('should round-trip through fromAmount', () => {
+      expect(MoneyUtils.toAmount(MoneyUtils.fromAmount(777))).toBe(777);
+    });
+  });
+});

--- a/spec/ObjectUtils.spec.ts
+++ b/spec/ObjectUtils.spec.ts
@@ -88,4 +88,14 @@ describe('ObjectUtils', () => {
       expect(beta['b']).toBe(alpha['b']);
     });
   });
+
+  describe('deepEquals', () => {
+    it('should return true for deeply equal objects', function () {
+      expect(ObjectUtils.deepEquals({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
+    });
+
+    it('should return false for objects with different values', function () {
+      expect(ObjectUtils.deepEquals({ a: 1 }, { a: 2 })).toBe(false);
+    });
+  });
 });

--- a/spec/ProcessUtils.spec.ts
+++ b/spec/ProcessUtils.spec.ts
@@ -34,6 +34,35 @@ describe('ProcessUtils', function () {
       const results: number[] = await processBatch(list, worker, status, 2);
       expect(results.length).toBe(3);
     });
+
+    it('should return results aligned with input order regardless of completion order', async () => {
+      // Larger inputs finish later, so completion order differs from input order.
+      const delays = [30, 5, 20, 1, 15];
+      const worker = async (ms: number): Promise<number> => {
+        await sleep(ms);
+        return ms;
+      };
+
+      const results = await processBatch(delays, worker, null, 8);
+
+      expect(results).toStrictEqual(delays);
+    });
+
+    it('should capture a thrown error as that element result instead of rejecting', async () => {
+      const worker = async (n: number): Promise<number> => {
+        if (n === 1) {
+          throw new Error('boom');
+        }
+        return n;
+      };
+
+      const results = await processBatch([0, 1, 2], worker, null, 8);
+
+      expect(results[0]).toBe(0);
+      expect(results[1]).toBeInstanceOf(Error);
+      expect((results[1] as unknown as Error).message).toBe('boom');
+      expect(results[2]).toBe(2);
+    });
   });
 
   describe('PromiseWaitAllNested', function () {

--- a/spec/RegexUtils.spec.ts
+++ b/spec/RegexUtils.spec.ts
@@ -1,0 +1,40 @@
+import { RegexUtils } from '@utils/RegexUtils';
+
+describe('RegexUtils', () => {
+  describe('escapeRegExp', () => {
+    it('should escape all regex special characters', () => {
+      expect(RegexUtils.escapeRegExp('a.b*c+?^${}()|[]\\')).toBe(
+        'a\\.b\\*c\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\'
+      );
+    });
+
+    it('should leave plain strings untouched', () => {
+      expect(RegexUtils.escapeRegExp('hello world')).toBe('hello world');
+    });
+
+    it('should produce a pattern that matches the literal string', () => {
+      const literal = 'a.c';
+      const re = new RegExp(RegexUtils.escapeRegExp(literal));
+      expect(re.test('a.c')).toBe(true);
+      // Without escaping, '.' would match any char; ensure it does not.
+      expect(re.test('abc')).toBe(false);
+    });
+  });
+
+  describe('startsWith', () => {
+    it('should match strings that start with the (escaped) term', () => {
+      const re = RegexUtils.startsWith('a.b');
+      expect(re.test('a.b-suffix')).toBe(true);
+      expect(re.test('xa.b')).toBe(false);
+      expect(re.test('aXb')).toBe(false);
+    });
+  });
+
+  describe('contains', () => {
+    it('should match strings that contain the (escaped) term anywhere', () => {
+      const re = RegexUtils.contains('a.b');
+      expect(re.test('prefix-a.b-suffix')).toBe(true);
+      expect(re.test('prefix-aXb-suffix')).toBe(false);
+    });
+  });
+});

--- a/spec/SecureObject.spec.ts
+++ b/spec/SecureObject.spec.ts
@@ -1,0 +1,29 @@
+import { SecureObject } from '@utils/parse/SecureObject';
+
+class TestSecureObject extends SecureObject {
+  constructor() {
+    super('TestSecureObject', ['secret']);
+  }
+}
+
+describe('SecureObject', () => {
+  beforeAll(() => {
+    // set() on a secure field requires a session derived key to be present. The value itself is
+    // only used when encrypting on save, so a stub key is enough to exercise the read/clone cache.
+    SecureObject.setSessionDerivedKey({ PBKDF2: {} as JsonWebKey });
+  });
+
+  describe('clone', () => {
+    it('should propagate the decrypted read cache to the clone (regression)', () => {
+      const obj = new TestSecureObject();
+      obj.set('secret', 'top-secret');
+
+      expect(obj.get('secret')).toBe('top-secret');
+
+      const clone = obj.clone();
+
+      // Before the fix, clone() copied in the wrong direction and the clone's cache stayed empty.
+      expect(clone.get('secret')).toBe('top-secret');
+    });
+  });
+});

--- a/spec/jestSetup.ts
+++ b/spec/jestSetup.ts
@@ -1,0 +1,7 @@
+// The library expects a global `Parse` provided by the consuming application
+// (browser build) or a Parse server. For tests we wire the Node build in as the
+// global so Parse-dependent modules can be imported and exercised.
+import Parse from 'parse/node';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).Parse = Parse;

--- a/src/ArrayUtils.ts
+++ b/src/ArrayUtils.ts
@@ -14,7 +14,7 @@ export class ArrayUtils {
       throw new Error('provided array is empty');
     }
 
-    return items[Math.floor(Math.random() * (items.length - 1))];
+    return items[Math.floor(Math.random() * items.length)];
   }
 
   static fillWith<T>(length: number, initializer: (index: number) => T): T[] {

--- a/src/ProcessUtils.ts
+++ b/src/ProcessUtils.ts
@@ -6,6 +6,18 @@ export function sleep(ms: number): Promise<void> {
 
 export type StringKeys<T> = Extract<keyof T, string>;
 
+/**
+ * Run `func` over `data` with at most `nbParallel` concurrent executions.
+ *
+ * Result contract:
+ * - The returned array is aligned with the input: `results[i]` is the outcome of `data[i]`,
+ *   regardless of the order in which the individual promises settle.
+ * - Errors are captured, not thrown: if `func` rejects for an element, the rejection reason
+ *   (typically an `Error`) is logged and stored as that element's result. Callers that need to
+ *   distinguish failures should check for `Error` instances in the returned array.
+ * - If `statusFunc` returns `false`, no new work is started; elements not yet processed are left
+ *   as empty slots in the returned array.
+ */
 export const processBatch = async <
   T,
   U,
@@ -36,7 +48,7 @@ export const processBatch = async <
       abortAll = true;
     }
 
-    results.push(result);
+    results[curIndex] = result;
 
     ++iCompleted;
   };

--- a/src/parse/SecureObject.ts
+++ b/src/parse/SecureObject.ts
@@ -74,8 +74,8 @@ export abstract class SecureObject extends BaseObject {
   clone(): this {
     const clone = super.clone();
 
-    for (const [k, v] of Object.entries(clone._decryptedReadCache)) {
-      this._decryptedReadCache[k] = v;
+    for (const [k, v] of Object.entries(this._decryptedReadCache)) {
+      clone._decryptedReadCache[k] = v;
     }
     return clone;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the top findings from the test-gap analysis / code review, plus deep Parse-backed tests for `Query`. Four logical commits:

### 1. Bug fixes (`fix:`)
- `ArrayUtils.randomElement` — off-by-one: it used `Math.floor(Math.random() * (items.length - 1))`, so the **last element was never returned** (`Math.random()` is `[0, 1)`). Now multiplies by `items.length` for a correct, uniform distribution.
- `SecureObject.clone` — copied the decrypted read cache in the **wrong direction** (read from the fresh, empty clone into `this`), leaving the clone's cache empty. Now copies `this` → `clone`.
- `ProcessUtils.processBatch` — results were pushed in **completion order**, so `results[i]` did not correspond to `data[i]`. Now writes by input index. Documented the ordering guarantee and the existing "errors are captured as results" contract in JSDoc.

### 2. Coverage visibility (`test:`)
- `jest.config.ts`: set `collectCoverageFrom: ['src/**/*.ts']` so untested modules show as `0%` instead of being silently omitted (previously only 8 of 20 files were even reported).
- Added `spec/jestSetup.ts` wiring `parse/node` as the global `Parse`, so the Parse-dependent modules can be imported during test/coverage runs.

### 3. New specs + spec cleanup (`test:`)
- New specs: `RegexUtils`, `CryptoUtils.isEncrypted` + base64 round-trip, `MoneyUtils`, `CurrencyUtils`, `ObjectUtils.deepEquals`, and a Parse-backed `SecureObject.clone` regression test.
- New `ArrayUtils` specs: `shuffle`, `uniqueByKey`, `sortByKey`, `toKeyArray`, `sum`.
- New `ProcessUtils` regression tests: input-order alignment and error capture.
- Fixed `spec/ArrayUtils.spec.ts` copy-paste defects: a mislabeled `fillWith` test, a verbatim-duplicated `randomElement` test (now asserts the last element is reachable), and a `filterByValue` "empty" test that actually called `randomElement`; replaced `global.Math` mutation with `jest.spyOn(Math, 'random')` + restore.

### 4. Parse-backed `Query` coverage (`test:`)
Added `spec/Query.spec.ts`, which stubs Parse's REST controller to exercise `Query` end-to-end without a server:
- auth/option plumbing (`runAsUser` / `useMasterKey` / `prepareOptions` + per-call overrides);
- `clone` state preservation, `include`/`limit`/`skip`, `whereQueries` same-class guard;
- `getObjectById` input handling (string / `Parse.Object` / Pointer / invalid / not-found);
- `findBy` / `findOneBy` / `findOrCreate` (existing, create+save, `save=false`, `createParams`);
- decryption hooks for `SecureObject` results on `find`/`first`;
- `subscribe` token selection and `liveQuery` initial population + create/update/delete reconciliation;
- `aggregate` / `distinct` / `findAll` / `each` delegation.

This raises `Query.ts` from ~14% to ~96% statements.

## Validation
- `yarn test` — **14 suites / 145 tests pass** (was 73 / 8).
- `yarn build` (`tsc`) — 0 errors.
- `yarn lint` (`eslint`) — clean.
- Coverage now lists all 20 source files. Overall statements ~78% (was an inflated 87.87% over only 8 files). `Query.ts` ~96%; `ArrayUtils`, `ObjectUtils`, `CurrencyUtils`, `MoneyUtils`, `RegexUtils`, `JSONUtils` at 100%; `ProcessUtils` ~98%.

## Notes / out of scope
- `StringUtils.toFixedOrNull` is still a duplicate of `toFloatOrNull` (no rounding despite the name). Left unchanged because "fixing" it is a behavior change that needs a product decision on the intended semantics.
- `SecureObject` and `CryptoUtils` remain partly covered (their crypto paths need `window.crypto`/jsdom); a follow-up could add a WebCrypto-enabled environment to exercise real encrypt/decrypt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b6bce29-e114-4bd6-8d18-9b8e15f1dc58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b6bce29-e114-4bd6-8d18-9b8e15f1dc58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

